### PR TITLE
multiple backslash when navigating fix

### DIFF
--- a/source/themes/graphene/layout.html
+++ b/source/themes/graphene/layout.html
@@ -122,9 +122,9 @@
   <!-- menu bar -->
   <div class='menubar'>
    <div class='section'>
-    <a href="{{ url_root }}/index.html"><img src="{{pathto('_static/grphn-logo.svg',1)}}" height="48" /></a>
-    <a href="{{ url_root }}/bitshares/index.html"><img src="{{pathto('_static/bitshares-logo.png',1)}}" height="48" /></a>
-    <a href="{{ url_root }}/muse/index.html"><img src="{{pathto('_static/MUSE_logo_transp_v1.png',1)}}" height="48" /></a>
+    <a href="{{ url_root }}index.html"><img src="{{pathto('_static/grphn-logo.svg',1)}}" height="48" /></a>
+    <a href="{{ url_root }}bitshares/index.html"><img src="{{pathto('_static/bitshares-logo.png',1)}}" height="48" /></a>
+    <a href="{{ url_root }}muse/index.html"><img src="{{pathto('_static/MUSE_logo_transp_v1.png',1)}}" height="48" /></a>
    </div>
    <div class='menu section'>
     <div id="toc">


### PR DESCRIPTION
when navigating from graphene to muse and bitshares by using the sidebar logos the backslash after domain gets repeated on each click so the url becames:
http://docs.bitshares.org/////muse/index.html
http://docs.bitshares.org//////bitshares/index.html
http://docs.bitshares.org//////////muse/index.html
and so on with each click ... this does not seems to be a problem as the documentation is still brow sable. still, it will look better if we can remove it. the following pull request attempt to fix it but is untested. please test before any merge.

thanks!