### PR TITLE
update project git clone

### DIFF
--- a/source/bitshares/installation/Sources.rst
+++ b/source/bitshares/installation/Sources.rst
@@ -7,7 +7,7 @@ with `git`.
 
 .. code-block:: sh
 
-    git clone https://github.com/bitshares/bitshares-2
+    git clone https://github.com/bitshares/bitshares-core
 
 Since the repository makes use of so called *submodules* which are repositories
 on their own, we need to refresh those.


### PR DESCRIPTION
command is currently working due to redirection but just keep things looking updated i changed the gihub url to the bitshares-core https://github.com/bitshares/bitshares-core/issues/425