### PR TITLE
complete command to don't connect to p2p

### DIFF
--- a/source/integration/apps/delayednode.rst
+++ b/source/integration/apps/delayednode.rst
@@ -20,4 +20,5 @@ intervals), we need:
 
     ./programs/delayed_node/delayed_node --trusted-node="192.168.0.100:8090" \
                                          --delay-block-count=10 \
-                                         --rpc-endpoint="192.168.0.101:8090"
+                                         --rpc-endpoint="192.168.0.101:8090" \
+                                         --seed-nodes "[]"


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/104
extended command so delayed node will not connect to p2p network.