### PR TITLE
Second tick required in --replay-blockchain

### DIFF
--- a/source/integration/apps/node.rst
+++ b/source/integration/apps/node.rst
@@ -87,7 +87,7 @@ Restarting the witness node
 ###########################
 
 When restarting the witness node, it may be required to append the
-`--replay-blockchain` parameter to regenerate the local (in-memory) blockchain
+``--replay-blockchain`` parameter to regenerate the local (in-memory) blockchain
 state.
 
 Enabling Block Production


### PR DESCRIPTION
For some reason the help docs weren't reproducing `--` properly